### PR TITLE
Isolate `OwnerManager`, `Safe.checkSignatures`, and `Safe.domainSeparator()`

### DIFF
--- a/contracts/CheckSignatures.sol
+++ b/contracts/CheckSignatures.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.7.0 <0.9.0;
 
 import "./base/IsolatedOwnerManager.sol";
 import "./common/SignatureDecoder.sol";
-import "./interfaces/ISignatureValidator.sol";
 import "./external/SafeMath.sol";
 
 /**
@@ -13,11 +12,6 @@ import "./external/SafeMath.sol";
  */
 abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
     using SafeMath for uint256;
-
-    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
-
-    // Mapping to keep track of all hashes (message or transaction) that have been approved by ANY owners
-    mapping(address => mapping(bytes32 => uint256)) public approvedHashes;
 
     // This constructor ensures that this contract can only be used as a singleton for proxy contracts
     constructor() {
@@ -65,43 +59,7 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
         uint256 i;
         for (i = 0; i < requiredSignatures; i++) {
             (v, r, s) = signatureSplit(signatures, i);
-            if (v == 0) {
-                require(keccak256(data) == dataHash, "GS027");
-                // If v is 0 then it is a contract signature
-                // When handling contract signatures the address of the contract is encoded into r
-                currentOwner = address(uint160(uint256(r)));
-
-                // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
-                // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
-                // Here we only check that the pointer is not pointing inside the part that is being processed
-                require(uint256(s) >= requiredSignatures.mul(65), "GS021");
-
-                // Check that signature data pointer (s) is in bounds (points to the length of data -> 32 bytes)
-                require(uint256(s).add(32) <= signatures.length, "GS022");
-
-                // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
-                uint256 contractSignatureLen;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    contractSignatureLen := mload(add(add(signatures, s), 0x20))
-                }
-                require(uint256(s).add(32).add(contractSignatureLen) <= signatures.length, "GS023");
-
-                // Check signature
-                bytes memory contractSignature;
-                // solhint-disable-next-line no-inline-assembly
-                assembly {
-                    // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
-                    contractSignature := add(add(signatures, s), 0x20)
-                }
-                require(ISignatureValidator(currentOwner).isValidSignature(data, contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
-            } else if (v == 1) {
-                // If v is 1 then it is an approved hash
-                // When handling approved hashes the address of the approver is encoded into r
-                currentOwner = address(uint160(uint256(r)));
-                // Hashes are automatically approved by the sender of the message or when they have been pre-approved via a separate transaction
-                require(msg.sender == currentOwner || approvedHashes[currentOwner][dataHash] != 0, "GS025");
-            } else if (v > 30) {
+            if (v > 30) {
                 // If v > 30 then default va (27,28) has been adjusted for eth_sign flow
                 // To support eth_sign and similar we adjust v and hash the messageHash with the Ethereum message prefix before applying ecrecover
                 currentOwner = ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", dataHash)), v - 4, r, s);
@@ -113,17 +71,5 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
             require(currentOwner > lastOwner && owners[currentOwner] != address(0) && currentOwner != SENTINEL_OWNERS, "GS026");
             lastOwner = currentOwner;
         }
-    }
-
-    /**
-     * @notice Marks hash `hashToApprove` as approved.
-     * @dev This can be used with a pre-approved hash transaction signature.
-     *      IMPORTANT: The approved hash stays approved forever. There's no revocation mechanism, so it behaves similarly to ECDSA signatures
-     * @param hashToApprove The hash to mark as approved for signatures that are verified by this contract.
-     */
-    function approveHash(bytes32 hashToApprove) external {
-        require(owners[msg.sender] != address(0), "GS030");
-        approvedHashes[msg.sender][hashToApprove] = 1;
-        emit ApproveHash(hashToApprove, msg.sender);
     }
 }

--- a/contracts/CheckSignatures.sol
+++ b/contracts/CheckSignatures.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+import "./base/OwnerManager.sol";
+import "./common/SignatureDecoder.sol";
+import "./interfaces/ISignatureValidator.sol";
+import "./external/SafeMath.sol";
+
+/**
+ * @title CheckSignatures - An abstract contract with only `checkSignatures` isolated from `Safe`.
+ * @author Stefan George - @Georgi87
+ * @author Richard Meissner - @rmeissner
+ */
+abstract contract CheckSignatures is OwnerManager, SignatureDecoder {
+    using SafeMath for uint256;
+
+    event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
+
+    // Mapping to keep track of all hashes (message or transaction) that have been approved by ANY owners
+    mapping(address => mapping(bytes32 => uint256)) public approvedHashes;
+
+    // This constructor ensures that this contract can only be used as a singleton for Proxy contracts
+    constructor() {
+        /**
+         * By setting the threshold it is not possible to call setup anymore,
+         * so we create a Safe with 0 owners and threshold 1.
+         * This is an unusable Safe, perfect for the singleton
+         */
+        threshold = 1;
+    }
+
+    /**
+     * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+     * @param data That should be signed (this is passed to an external validator contract)
+     * @param signatures Signature data that should be verified.
+     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
+     */
+    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) public view {
+        // Load threshold to avoid multiple storage loads
+        uint256 _threshold = threshold;
+        // Check that a threshold is set
+        require(_threshold > 0, "GS001");
+        checkNSignatures(dataHash, data, signatures, _threshold);
+    }
+
+    /**
+     * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
+     * @dev Since the EIP-1271 does an external call, be mindful of reentrancy attacks.
+     * @param dataHash Hash of the data (could be either a message hash or transaction hash)
+     * @param data That should be signed (this is passed to an external validator contract)
+     * @param signatures Signature data that should be verified.
+     *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
+     * @param requiredSignatures Amount of required valid signatures.
+     */
+    function checkNSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, uint256 requiredSignatures) public view {
+        // Check that the provided signature data is not too short
+        require(signatures.length >= requiredSignatures.mul(65), "GS020");
+        // There cannot be an owner with address 0.
+        address lastOwner = address(0);
+        address currentOwner;
+        uint8 v;
+        bytes32 r;
+        bytes32 s;
+        uint256 i;
+        for (i = 0; i < requiredSignatures; i++) {
+            (v, r, s) = signatureSplit(signatures, i);
+            if (v == 0) {
+                require(keccak256(data) == dataHash, "GS027");
+                // If v is 0 then it is a contract signature
+                // When handling contract signatures the address of the contract is encoded into r
+                currentOwner = address(uint160(uint256(r)));
+
+                // Check that signature data pointer (s) is not pointing inside the static part of the signatures bytes
+                // This check is not completely accurate, since it is possible that more signatures than the threshold are send.
+                // Here we only check that the pointer is not pointing inside the part that is being processed
+                require(uint256(s) >= requiredSignatures.mul(65), "GS021");
+
+                // Check that signature data pointer (s) is in bounds (points to the length of data -> 32 bytes)
+                require(uint256(s).add(32) <= signatures.length, "GS022");
+
+                // Check if the contract signature is in bounds: start of data is s + 32 and end is start + signature length
+                uint256 contractSignatureLen;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    contractSignatureLen := mload(add(add(signatures, s), 0x20))
+                }
+                require(uint256(s).add(32).add(contractSignatureLen) <= signatures.length, "GS023");
+
+                // Check signature
+                bytes memory contractSignature;
+                // solhint-disable-next-line no-inline-assembly
+                assembly {
+                    // The signature data for contract signatures is appended to the concatenated signatures and the offset is stored in s
+                    contractSignature := add(add(signatures, s), 0x20)
+                }
+                require(ISignatureValidator(currentOwner).isValidSignature(data, contractSignature) == EIP1271_MAGIC_VALUE, "GS024");
+            } else if (v == 1) {
+                // If v is 1 then it is an approved hash
+                // When handling approved hashes the address of the approver is encoded into r
+                currentOwner = address(uint160(uint256(r)));
+                // Hashes are automatically approved by the sender of the message or when they have been pre-approved via a separate transaction
+                require(msg.sender == currentOwner || approvedHashes[currentOwner][dataHash] != 0, "GS025");
+            } else if (v > 30) {
+                // If v > 30 then default va (27,28) has been adjusted for eth_sign flow
+                // To support eth_sign and similar we adjust v and hash the messageHash with the Ethereum message prefix before applying ecrecover
+                currentOwner = ecrecover(keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", dataHash)), v - 4, r, s);
+            } else {
+                // Default is the ecrecover flow with the provided data hash
+                // Use ecrecover with the messageHash for EOA signatures
+                currentOwner = ecrecover(dataHash, v, r, s);
+            }
+            require(currentOwner > lastOwner && owners[currentOwner] != address(0) && currentOwner != SENTINEL_OWNERS, "GS026");
+            lastOwner = currentOwner;
+        }
+    }
+
+    /**
+     * @notice Marks hash `hashToApprove` as approved.
+     * @dev This can be used with a pre-approved hash transaction signature.
+     *      IMPORTANT: The approved hash stays approved forever. There's no revocation mechanism, so it behaves similarly to ECDSA signatures
+     * @param hashToApprove The hash to mark as approved for signatures that are verified by this contract.
+     */
+    function approveHash(bytes32 hashToApprove) external {
+        require(owners[msg.sender] != address(0), "GS030");
+        approvedHashes[msg.sender][hashToApprove] = 1;
+        emit ApproveHash(hashToApprove, msg.sender);
+    }
+}

--- a/contracts/CheckSignatures.sol
+++ b/contracts/CheckSignatures.sol
@@ -26,7 +26,6 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
     /**
      * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
-     * @param data That should be signed (this is passed to an external validator contract)
      * @param signatures Signature data that should be verified.
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      */
@@ -42,7 +41,6 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
      * @notice Checks whether the signature provided is valid for the provided data and hash. Reverts otherwise.
      * @dev Since the EIP-1271 does an external call, be mindful of reentrancy attacks.
      * @param dataHash Hash of the data (could be either a message hash or transaction hash)
-     * @param data That should be signed (this is passed to an external validator contract)
      * @param signatures Signature data that should be verified.
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      * @param requiredSignatures Amount of required valid signatures.

--- a/contracts/CheckSignatures.sol
+++ b/contracts/CheckSignatures.sol
@@ -30,12 +30,12 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
      * @param signatures Signature data that should be verified.
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      */
-    function checkSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures) public view {
+    function checkSignatures(bytes32 dataHash, bytes memory signatures) public view {
         // Load threshold to avoid multiple storage loads
         uint256 _threshold = threshold;
         // Check that a threshold is set
         require(_threshold > 0, "GS001");
-        checkNSignatures(dataHash, data, signatures, _threshold);
+        checkNSignatures(dataHash, signatures, _threshold);
     }
 
     /**
@@ -47,7 +47,7 @@ abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
      *                   Can be packed ECDSA signature ({bytes32 r}{bytes32 s}{uint8 v}), contract signature (EIP-1271) or approved hash.
      * @param requiredSignatures Amount of required valid signatures.
      */
-    function checkNSignatures(bytes32 dataHash, bytes memory data, bytes memory signatures, uint256 requiredSignatures) public view {
+    function checkNSignatures(bytes32 dataHash, bytes memory signatures, uint256 requiredSignatures) public view {
         // Check that the provided signature data is not too short
         require(signatures.length >= requiredSignatures.mul(65), "GS020");
         // There cannot be an owner with address 0.

--- a/contracts/CheckSignatures.sol
+++ b/contracts/CheckSignatures.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity >=0.7.0 <0.9.0;
 
-import "./base/OwnerManager.sol";
+import "./base/IsolatedOwnerManager.sol";
 import "./common/SignatureDecoder.sol";
 import "./interfaces/ISignatureValidator.sol";
 import "./external/SafeMath.sol";
@@ -11,7 +11,7 @@ import "./external/SafeMath.sol";
  * @author Stefan George - @Georgi87
  * @author Richard Meissner - @rmeissner
  */
-abstract contract CheckSignatures is OwnerManager, SignatureDecoder {
+abstract contract CheckSignatures is IsolatedOwnerManager, SignatureDecoder {
     using SafeMath for uint256;
 
     event ApproveHash(bytes32 indexed approvedHash, address indexed owner);
@@ -19,12 +19,12 @@ abstract contract CheckSignatures is OwnerManager, SignatureDecoder {
     // Mapping to keep track of all hashes (message or transaction) that have been approved by ANY owners
     mapping(address => mapping(bytes32 => uint256)) public approvedHashes;
 
-    // This constructor ensures that this contract can only be used as a singleton for Proxy contracts
+    // This constructor ensures that this contract can only be used as a singleton for proxy contracts
     constructor() {
         /**
-         * By setting the threshold it is not possible to call setup anymore,
-         * so we create a Safe with 0 owners and threshold 1.
-         * This is an unusable Safe, perfect for the singleton
+         * By setting the threshold it is not possible to call setupOwners anymore,
+         * so we create a contract with 0 owners and threshold 1.
+         * This is an unusable contract, perfect for the singleton
          */
         threshold = 1;
     }

--- a/contracts/EIP712DomainSeparator.sol
+++ b/contracts/EIP712DomainSeparator.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+/**
+ * @title EIP712DomainSeparator - An abstract contract with only `domainSeparator` isolated from `Safe`.
+ * @author Stefan George - @Georgi87
+ * @author Richard Meissner - @rmeissner
+ */
+abstract contract EIP712DomainSeparator {
+    // keccak256(
+    //     "EIP712Domain(uint256 chainId,address verifyingContract)"
+    // );
+    bytes32 private constant DOMAIN_SEPARATOR_TYPEHASH = 0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218;
+
+    /**
+     * @notice Returns the ID of the chain the contract is currently deployed on.
+     * @return The ID of the current chain as a uint256.
+     */
+    function getChainId() public view returns (uint256) {
+        uint256 id;
+        // solhint-disable-next-line no-inline-assembly
+        assembly {
+            id := chainid()
+        }
+        return id;
+    }
+
+    /**
+     * @dev Returns the domain separator for this contract, as defined in the EIP-712 standard.
+     * @return bytes32 The domain separator hash.
+     */
+    function domainSeparator() public view returns (bytes32) {
+        return keccak256(abi.encode(DOMAIN_SEPARATOR_TYPEHASH, getChainId(), this));
+    }
+}

--- a/contracts/base/IsolatedOwnerManager.sol
+++ b/contracts/base/IsolatedOwnerManager.sol
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+import "../common/SafeAuthorized.sol";
+
+/**
+ * @title IsolatedOwnerManager - Manages Safe owners and a threshold to authorize transactions.
+ * @dev Uses a linked list to store the owners because the code generate by the solidity compiler
+ *      is more efficient than using a dynamic array.
+ * @author Stefan George - @Georgi87
+ * @author Richard Meissner - @rmeissner
+ */
+abstract contract IsolatedOwnerManager is SafeAuthorized {
+    event AddedOwner(address indexed owner);
+    event RemovedOwner(address indexed owner);
+    event ChangedThreshold(uint256 threshold);
+
+    address internal constant SENTINEL_OWNERS = address(0x1);
+
+    mapping(address => address) internal owners;
+    uint256 internal ownerCount;
+    uint256 internal threshold;
+
+    /**
+     * @notice Sets the initial storage of the contract.
+     * @param _owners List of Safe owners.
+     * @param _threshold Number of required confirmations for a Safe transaction.
+     */
+    function setupOwners(address[] memory _owners, uint256 _threshold) internal {
+        // Threshold can only be 0 at initialization.
+        // Check ensures that setup function can only be called once.
+        require(threshold == 0, "GS200");
+        // Validate that threshold is smaller than number of added owners.
+        require(_threshold <= _owners.length, "GS201");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "GS202");
+        // Initializing Safe owners.
+        address currentOwner = SENTINEL_OWNERS;
+        for (uint256 i = 0; i < _owners.length; i++) {
+            // Owner address cannot be null.
+            address owner = _owners[i];
+            require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this) && currentOwner != owner, "GS203");
+            // No duplicate owners allowed.
+            require(owners[owner] == address(0), "GS204");
+            owners[currentOwner] = owner;
+            currentOwner = owner;
+        }
+        owners[currentOwner] = SENTINEL_OWNERS;
+        ownerCount = _owners.length;
+        threshold = _threshold;
+    }
+
+    /**
+     * @notice Adds the owner `owner` to the Safe and updates the threshold to `_threshold`.
+     * @dev This can only be done via a Safe transaction.
+     * @param owner New owner address.
+     * @param _threshold New threshold.
+     */
+    function addOwnerWithThreshold(address owner, uint256 _threshold) public authorized {
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(owner != address(0) && owner != SENTINEL_OWNERS && owner != address(this), "GS203");
+        // No duplicate owners allowed.
+        require(owners[owner] == address(0), "GS204");
+        owners[owner] = owners[SENTINEL_OWNERS];
+        owners[SENTINEL_OWNERS] = owner;
+        ownerCount++;
+        emit AddedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold) changeThreshold(_threshold);
+    }
+
+    /**
+     * @notice Removes the owner `owner` from the Safe and updates the threshold to `_threshold`.
+     * @dev This can only be done via a Safe transaction.
+     * @param prevOwner Owner that pointed to the owner to be removed in the linked list
+     * @param owner Owner address to be removed.
+     * @param _threshold New threshold.
+     */
+    function removeOwner(address prevOwner, address owner, uint256 _threshold) public authorized {
+        // Only allow to remove an owner, if threshold can still be reached.
+        require(ownerCount - 1 >= _threshold, "GS201");
+        // Validate owner address and check that it corresponds to owner index.
+        require(owner != address(0) && owner != SENTINEL_OWNERS, "GS203");
+        require(owners[prevOwner] == owner, "GS205");
+        owners[prevOwner] = owners[owner];
+        owners[owner] = address(0);
+        ownerCount--;
+        emit RemovedOwner(owner);
+        // Change threshold if threshold was changed.
+        if (threshold != _threshold) changeThreshold(_threshold);
+    }
+
+    /**
+     * @notice Replaces the owner `oldOwner` in the Safe with `newOwner`.
+     * @dev This can only be done via a Safe transaction.
+     * @param prevOwner Owner that pointed to the owner to be replaced in the linked list
+     * @param oldOwner Owner address to be replaced.
+     * @param newOwner New owner address.
+     */
+    function swapOwner(address prevOwner, address oldOwner, address newOwner) public authorized {
+        // Owner address cannot be null, the sentinel or the Safe itself.
+        require(newOwner != address(0) && newOwner != SENTINEL_OWNERS && newOwner != address(this), "GS203");
+        // No duplicate owners allowed.
+        require(owners[newOwner] == address(0), "GS204");
+        // Validate oldOwner address and check that it corresponds to owner index.
+        require(oldOwner != address(0) && oldOwner != SENTINEL_OWNERS, "GS203");
+        require(owners[prevOwner] == oldOwner, "GS205");
+        owners[newOwner] = owners[oldOwner];
+        owners[prevOwner] = newOwner;
+        owners[oldOwner] = address(0);
+        emit RemovedOwner(oldOwner);
+        emit AddedOwner(newOwner);
+    }
+
+    /**
+     * @notice Changes the threshold of the Safe to `_threshold`.
+     * @dev This can only be done via a Safe transaction.
+     * @param _threshold New threshold.
+     */
+    function changeThreshold(uint256 _threshold) public authorized {
+        // Validate that threshold is smaller than number of owners.
+        require(_threshold <= ownerCount, "GS201");
+        // There has to be at least one Safe owner.
+        require(_threshold >= 1, "GS202");
+        threshold = _threshold;
+        emit ChangedThreshold(threshold);
+    }
+
+    /**
+     * @notice Returns the number of required confirmations for a Safe transaction aka the threshold.
+     * @return Threshold number.
+     */
+    function getThreshold() public view returns (uint256) {
+        return threshold;
+    }
+
+    /**
+     * @notice Returns if `owner` is an owner of the Safe.
+     * @return Boolean if owner is an owner of the Safe.
+     */
+    function isOwner(address owner) public view returns (bool) {
+        return owner != SENTINEL_OWNERS && owners[owner] != address(0);
+    }
+
+    /**
+     * @notice Returns a list of Safe owners.
+     * @return Array of Safe owners.
+     */
+    function getOwners() public view returns (address[] memory) {
+        address[] memory array = new address[](ownerCount);
+
+        // populate return array
+        uint256 index = 0;
+        address currentOwner = owners[SENTINEL_OWNERS];
+        while (currentOwner != SENTINEL_OWNERS) {
+            array[index] = currentOwner;
+            currentOwner = owners[currentOwner];
+            index++;
+        }
+        return array;
+    }
+}

--- a/contracts/common/SafeAuthorized.sol
+++ b/contracts/common/SafeAuthorized.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity >=0.7.0 <0.9.0;
+
+import "../Safe.sol";
+
+/**
+ * @title SafeAuthorized - Authorizes a `Safe` to perform actions to the current contract.
+ * @author Richard Meissner - @rmeissner
+ */
+abstract contract SafeAuthorized {
+    Safe public safe;
+
+    function requireSafeCall() private view {
+        require(msg.sender == address(safe), "GS031");
+    }
+
+    modifier authorized() {
+        // Modifiers are copied around during compilation. This is a function call as it minimized the bytecode size
+        requireSafeCall();
+        _;
+    }
+}


### PR DESCRIPTION
Added files are as follows:
- `contracts/SafeAuthorized.sol`: identical fork of `SelfAuthorized.sol` but it validates that the sender is the `Safe`, not `this`.
- `contracts/base/IsolatedOwnerManager.sol`: identical fork of `OwnerManager` but extends `SafeAuthorized` instead of `SelfAuthorized`.
- `contracts/CheckSignatures.sol`: isolated/extracted version of the `Safe.checkSignatures` function--all of the code in this contract has been extracted from `Safe.sol`.
- `contracts/EIP712DomainSeparator.sol`: EIP-712 `domainSeparator()` function--all of the code in this contract has been extracted from `Safe.sol`.